### PR TITLE
Move example dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,14 @@
         "jest": "^25.1.0",
         "parcel-bundler": "^1.12.3",
         "prettier": "^1.18.2",
+        "react": "^16.13.0",
+        "react-dom": "^16.13.0",
         "react-test-renderer": "^16.13.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.0.2",
         "rollup-plugin-eslint": "^7.0.0",
         "rollup-plugin-typescript2": "^0.26.0",
+        "styled-components": "^4.4.1",
         "ts-jest": "^25.2.1",
         "typescript": "^3.8.3"
     },
@@ -67,9 +70,6 @@
         "animejs": "^3.1.0",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
-        "query-string": "^6.11.1",
-        "react": "^16.13.0",
-        "react-dom": "^16.13.0",
-        "styled-components": "^4.4.1"
+        "query-string": "^6.11.1"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,9 @@ export interface ICurrentLocationStore<State> {
 class UrlStore<State> implements ICurrentLocationStore<State> {
     public queryParamKey: string;
     public observers: Array<StateObserver<State>>;
-    public stateWatcher: ReturnType<typeof window.setInterval>;
+    public stateWatcher: ReturnType<typeof setInterval>;
     public existingLocation: string;
-    public setIntervalHandle: number;
+    public setIntervalHandle: ReturnType<typeof setInterval>;
 
     constructor(queryParamKey: string) {
         this.queryParamKey = queryParamKey;


### PR DESCRIPTION
Forgive me if I'm misunderstanding the package structure, by my impression is that the `app` directory is not used in the distribution build. This patch moves the dependencies that are only used by `app` into devDependencies. I noticed this issue when I was looking through the lockfile and noticed that multiple versions of styled-components and react were being installed. This _should_ remove quite a bit of code from dependents' node_modules.